### PR TITLE
Reduce unrelated changes comparing to original

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -19,7 +19,7 @@
   |             Hannes Magnusson <bjori@php.net>                         |
   |             Gwynne Raskind <gwynne@php.net>                          |
   +----------------------------------------------------------------------+
-
+  
   $Id$
 */
 
@@ -31,7 +31,7 @@ echo "configure.php: $cvs_id\n";
 function usage() // {{{
 {
     global $acd;
-
+    
     echo <<<HELPCHUNK
 configure.php configures this package to adapt to many kinds of systems, and PhD
 builds too.
@@ -66,7 +66,7 @@ Package-specific:
   --with-php=PATH                Path to php CLI executable [detect]
   --with-lang=LANG               Language to build [{$acd['LANG']}]
   --with-partial=my-xml-id       Root ID to build (e.g. <book xml:id="MY-ID">) [{$acd['PARTIAL']}]
-  --disable-broken-file-listing  Do not ignore translated files in
+  --disable-broken-file-listing  Do not ignore translated files in 
                                  broken-files.txt
   --redirect-stderr-to-stdout    Redirect STDERR to STDOUT. Use STDOUT as the
                                  standard output for XML errors [{$acd['STDERR_TO_STDOUT']}]
@@ -97,7 +97,7 @@ function is_windows() {
 function checking($for) // {{{
 {
     global $ac;
-
+    
     if ($ac['quiet'] != 'yes') {
         echo "Checking {$for}... ";
         flush();
@@ -107,7 +107,7 @@ function checking($for) // {{{
 function checkerror($msg) // {{{
 {
     global $ac;
-
+    
     if ($ac['quiet'] != 'yes') {
         echo "\n";
     }
@@ -118,7 +118,7 @@ function checkerror($msg) // {{{
 function checkvalue($v) // {{{
 {
     global $ac;
-
+    
     if ($ac['quiet'] != 'yes') {
         echo "{$v}\n";
     }
@@ -315,7 +315,7 @@ foreach ($_SERVER['argv'] as $k => $opt) { // {{{
     } else {
         continue;
     }
-
+    
     $overridden_settings[] = strtoupper($o);
     switch ($o) {
         case 'h':
@@ -399,7 +399,7 @@ foreach ($_SERVER['argv'] as $k => $opt) { // {{{
         case 'basedir':
             $ac['basedir'] = $v;
             break;
-
+        
         case 'output':
             $ac['OUTPUT_FILENAME'] = $v;
             break;
@@ -414,7 +414,7 @@ foreach ($_SERVER['argv'] as $k => $opt) { // {{{
         case 'stderr-to-stdout':
             $ac['STDERR_TO_STDOUT'] = $v;
             break;
-
+            
         case '':
             break;
 
@@ -676,7 +676,7 @@ if ($ac['PARTIAL'] != '' && $ac['PARTIAL'] != 'no') { // {{{
     echo "done.\n";
     echo "Partial manual saved to {$filename}. To build it, run 'phd -d {$filename}'\n";
     exit(0);
-} // }}}
+} // }}} 
 
 $mxml = $ac["OUTPUT_FILENAME"];
 if ($dom->validate()) {
@@ -722,7 +722,7 @@ CAT;
     echo "\nThe document didn't validate, ";
 
     // Allow the .manual.xml file to be created, even if it is not valid.
-    if ($ac['FORCE_DOM_SAVE'] == 'yes') {
+    if ($ac['FORCE_DOM_SAVE'] == 'yes') { 
         printf("writing %s anyway, and ", basename($ac["OUTPUT_FILENAME"]));
         if ($ac["SEGFAULT_SPEED"] == "yes") {
             $t = $dom->doctype;
@@ -757,3 +757,4 @@ CAT;
     errors_are_bad(1); // Tell the shell that this script finished with an error.
 }
 ?>
+

--- a/scripts/revcheck.php
+++ b/scripts/revcheck.php
@@ -142,10 +142,10 @@ function get_original_info($file, $hash)
 // Grabs the revision tag and stores credits from the file given
 function get_tags($file, $val = "en-rev") {
 
-    global $LANG, $DOCDIR;
-    $basefile = substr($file, strlen($LANG) + 3);
+  global $LANG, $DOCDIR;
+  $basefile = substr($file, strlen($LANG) + 3);
 
-    // Read the first 500 chars. The comment should be at
+  // Read the first 500 chars. The comment should be at
   // the begining of the file
 
   $fp = @fopen($file, "r") or die ("Unable to read $file.");
@@ -155,8 +155,8 @@ function get_tags($file, $val = "en-rev") {
   // Check for English SVN revision tag (. is for $ in the preg!),
   // Return if this was needed (it should be there)
   if ($val == "en-rev") {
-      exec('cd ' . $DOCDIR . '/' . $LANG . ' && git log -1 --pretty=format:"%h %at" ' . $basefile, $result, $output);
-      return new DateTimeImmutable('@' . explode(' ', $result[0])[1]);
+    exec('cd ' . $DOCDIR . '/' . $LANG . ' && git log -1 --pretty=format:"%h %at" ' . $basefile, $result, $output);
+    return new DateTimeImmutable('@' . explode(' ', $result[0])[1]);
   }
 
   // Handle credits (only if no maintainer is specified)
@@ -207,8 +207,8 @@ function get_tags($file, $val = "en-rev") {
       preg_match (
           "'<!--\s*EN-Revision:\s*(n/a)\s*Maintainer:\s*("
                   . $val . ")\s*Status:\s*(.+)\s*-->'U",
-          $line,
-          $match
+                  $line,
+                  $match
       );
   }
 
@@ -382,6 +382,7 @@ function get_dir_status($dir) {
 
   // Walk through all names in the directory
   while ($file = @readdir($handle)) {
+  
     if (
     (!is_dir($dir.'/' .$file) && !in_array(substr($file, -3), array('xml','ent')) && substr($file, -13) != 'PHPEditBackup' )
     || strpos($file, 'entities.') === 0


### PR DESCRIPTION
Nothing big and even nonsense at the first glance but it reduces overall diff comparing to the original. I fully agree that these whitespace mistakes should be dealt with but having them as a part of this project actually makes the diff harder to read.

Please compare [this original diff](https://github.com/phpdoctest/doc-base/compare/f71b7f2499fa7d897722f4a479bb1d0ecc9738a2...master) against [mine](https://github.com/Sobak/doc-base/compare/f71b7f2499fa7d897722f4a479bb1d0ecc9738a2...10249ff69e1974c540bc7a8dc5097788fdca871d) and you'll see what I'm talking about.

PS: I know it's just because of IDE stripping trailing whitespaces
PPS: I think we should squash this commit at some point